### PR TITLE
[12.0] [IMP] to multi-store modules (#24)

### DIFF
--- a/account_multi_store/__manifest__.py
+++ b/account_multi_store/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Multi Store for Accounting',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.1.0',
     'category': 'Accounting',
     'sequence': 14,
     'summary': '',

--- a/account_multi_store/migrations/12.0.1.1.0/mig_data.xml
+++ b/account_multi_store/migrations/12.0.1.1.0/mig_data.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="account_journal_store_rule" model="ir.rule">
+        <field name="perm_read" eval="False"/>
+    </record>
+
+</odoo>

--- a/account_multi_store/migrations/12.0.1.1.0/pre-migration.py
+++ b/account_multi_store/migrations/12.0.1.1.0/pre-migration.py
@@ -1,0 +1,7 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.load_data(
+        env.cr, 'account_multi_store', 'migrations/12.0.1.1.0/mig_data.xml')

--- a/account_multi_store/models/account_journal.py
+++ b/account_multi_store/models/account_journal.py
@@ -2,7 +2,7 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import models, fields
+from odoo import models, fields, api
 
 
 class AccountJournal(models.Model):
@@ -15,3 +15,19 @@ class AccountJournal(models.Model):
         " store, can only see this journal records but can not post or modify "
         " any entry on them."
     )
+
+    @api.model
+    def search(self, args, offset=0, limit=None, order=None, count=False):
+        """
+        Para que usuarios los usuarios no puedan elegir diarios donde no puedan
+        escribir, modificamos la funcion search. No lo hacemos por regla de
+        permiso ya que si no pueden ver los diarios termina dando errores en
+        cualquier lugar que se use un campo related a algo del diario
+        """
+        user = self.env.user
+        # if superadmin, do not apply
+        if user.id != 1:
+            args += ['|', ('store_id', '=', False), ('store_id', 'child_of', [user.store_id.id])]
+
+        return super(AccountJournal, self).search(
+            args, offset, limit, order, count=count)

--- a/account_multi_store/security/multi_store_security.xml
+++ b/account_multi_store/security/multi_store_security.xml
@@ -5,6 +5,7 @@
         <field name="model_id" ref="account.model_account_journal"/>
         <field name="global" eval="True"/>
         <field name="domain_force">['|',('store_id','=',False),('store_id','child_of',[user.store_id.id])]</field>
+        <field name="perm_read" eval="False"/>
     </record>
 
     <record id="account_move_store_rule" model="ir.rule">

--- a/base_multi_store/__manifest__.py
+++ b/base_multi_store/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Multi Stores Management',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.1.0',
     'category': 'Accounting',
     'sequence': 14,
     'summary': '',

--- a/base_multi_store/views/res_users_view.xml
+++ b/base_multi_store/views/res_users_view.xml
@@ -21,7 +21,7 @@
         <field name="inherit_id" ref="base.view_users_form_simple_modif"/>
         <field name="arch" type="xml">
             <field name="company_id" position="after">
-                <field name="store_id" domain="[('company_id', '=', company_id)]" readonly="0" contest="{'user_preference':0}" options="{'no_create': True}" groups="base_multi_store.group_multi_store"/>
+                <field name="store_id" domain="['|', ('company_id', '=', False),('company_id', '=', company_id)]" readonly="0" contest="{'user_preference':0}" options="{'no_create': True}" groups="base_multi_store.group_multi_store"/>
             </field>
         </field>
     </record>

--- a/stock_multi_store/__manifest__.py
+++ b/stock_multi_store/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Multi Store for Warehouse',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.1.0',
     'category': 'Accounting',
     'sequence': 14,
     'summary': '',

--- a/stock_multi_store/migrations/12.0.1.1.0/mig_data.xml
+++ b/stock_multi_store/migrations/12.0.1.1.0/mig_data.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="stock_picking_type_store_rule" model="ir.rule">
+        <field name="perm_read" eval="False"/>
+    </record>
+</odoo>

--- a/stock_multi_store/migrations/12.0.1.1.0/pre-migration.py
+++ b/stock_multi_store/migrations/12.0.1.1.0/pre-migration.py
@@ -1,0 +1,7 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.load_data(
+        env.cr, 'stock_multi_store', 'migrations/12.0.1.1.0/mig_data.xml')

--- a/stock_multi_store/models/stock_picking_type.py
+++ b/stock_multi_store/models/stock_picking_type.py
@@ -2,7 +2,7 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import models, fields
+from odoo import models, fields, api
 
 
 class StockPickingType(models.Model):
@@ -12,3 +12,17 @@ class StockPickingType(models.Model):
         related='warehouse_id.store_id',
         store=True,
     )
+
+    @api.model
+    def search(self, args, offset=0, limit=None, order=None, count=False):
+        """
+        Para que usuarios los usuarios no puedan elegir pickings donde no puedan
+        escribir, modificamos la funcion search. No lo hacemos por regla de
+        permiso ya que si no pueden ver los diarios termina dando errores en
+        cualquier lugar que se use un campo related a algo del diario
+        """
+        user = self.env.user
+        # if superadmin, do not apply
+        if user.id != 1:
+            args += ['|', ('store_id', '=', False), ('store_id', 'child_of', [user.store_id.id])]
+        return super().search(args, offset, limit, order, count=count)

--- a/stock_multi_store/models/stock_warehouse.py
+++ b/stock_multi_store/models/stock_warehouse.py
@@ -2,7 +2,7 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import models, fields
+from odoo import models, fields, api
 
 
 class StockWarehouse(models.Model):
@@ -15,3 +15,17 @@ class StockWarehouse(models.Model):
         " store, can only see this warehouse records but can not post or"
         " modify any record related to them."
     )
+
+    @api.model
+    def search(self, args, offset=0, limit=None, order=None, count=False):
+        """
+        Para que usuarios los usuarios no puedan elegir almacenes donde no puedan
+        escribir, modificamos la funcion search. No lo hacemos por regla de
+        permiso ya que si no pueden ver los diarios termina dando errores en
+        cualquier lugar que se use un campo related a algo del diario
+        """
+        user = self.env.user
+        # if superadmin, do not apply
+        if user.id != 1:
+            args += ['|', ('store_id', '=', False), ('store_id', 'child_of', [user.store_id.id])]
+        return super().search(args, offset, limit, order, count=count)

--- a/stock_multi_store/security/multi_store_security.xml
+++ b/stock_multi_store/security/multi_store_security.xml
@@ -15,6 +15,7 @@
         <field name="model_id" ref="stock.model_stock_picking_type"/>
         <field name="global" eval="True"/>
         <field name="domain_force">['|',('warehouse_id.store_id','=',False),('warehouse_id.store_id','child_of',[user.store_id.id])]</field>
+        <field name="perm_read" eval="False"/>
     </record>
 
     <record id="stock_picking_store_rule" model="ir.rule">


### PR DESCRIPTION
* [FIX] base_multi_store: Fix the name search method

Readapt the method name_search  in res.store to filter only by the store that the user has allowed.
Change in res user view to add in the domain to store witout company set.

* [REF] account_multi_store: change the logic to restrict read accion

* [REF] stock_multi_store: Readpt the logic to restring stores in stock