### PR TITLE
[13.0] [FIX] base_multi_store: Adpat res user my profile view.

### DIFF
--- a/base_multi_store/__manifest__.py
+++ b/base_multi_store/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Multi Stores Management',
-    'version': '13.0.1.1.0',
+    'version': '13.0.1.2.0',
     'category': 'Accounting',
     'sequence': 14,
     'summary': '',

--- a/base_multi_store/views/res_users_view.xml
+++ b/base_multi_store/views/res_users_view.xml
@@ -22,7 +22,7 @@
         <field name="arch" type="xml">
             <group name="preferences">
                 <group name="stores">
-                    <field name="store_id" context="{'user_preference':0}" options="{'no_create': True}" groups="base_multi_store.group_multi_store"/>
+                    <field name="store_id" context="{'user_preference':0}" options="{'no_create': True}"/>
                 </group>
             </group>
         </field>


### PR DESCRIPTION
We alredy retrict the store who can select and for some module "HR" we have problems with this groups in that view.
if the user has more than one store allowed, then they can choose only this between this stores it's not necessary restrict the field showed.