### PR TITLE
[REF] pay_group_multi_store: add do not compute wth to multi store

### DIFF
--- a/account_multi_store/__manifest__.py
+++ b/account_multi_store/__manifest__.py
@@ -43,6 +43,7 @@
     'demo': [
         # TODO fix demo data, perhups yml
         # 'demo/account_demo.xml',
+        'demo/res_store_demo.xml',
     ],
     'installable': True,
     'auto_install': True,

--- a/account_multi_store/demo/res_store_demo.xml
+++ b/account_multi_store/demo/res_store_demo.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="unidad_a_store" model="res.store">
+        <field name="name">Unidad A</field>
+        <field name="parent_id" ref="base_multi_store.shared_store"/>
+        <field name="only_allow_reonciliaton_of_this_store" eval="True"/>
+    </record>
+
+    <record id="unidad_b_store" model="res.store">
+        <field name="name">Unidad B</field>
+        <field name="only_allow_reonciliaton_of_this_store" eval="True"/>
+        <field name="parent_id" ref="base_multi_store.shared_store"/>
+    </record>
+
+</odoo>

--- a/account_multi_store/models/account_move_line.py
+++ b/account_multi_store/models/account_move_line.py
@@ -23,3 +23,22 @@ class AccountMoveLine(models.Model):
                 raise UserError(_(
                     'For store "%s" you can only reconcile lines of same store') % (line.store_id.display_name))
         return super().reconcile()
+
+    def _prepare_exchange_difference_move_vals(self, amounts_list, company=None, exchange_date=None):
+        """ Ajustamos para usar diario de diferencia de cambio seteado en los stores
+        """
+        vals = super()._prepare_exchange_difference_move_vals(amounts_list, company=company, exchange_date=exchange_date)
+        company = self.company_id or company
+        if not company:
+            return
+        currency_exchange_journal = self.mapped('journal_id.store_id.currency_exchange_journal_id')
+        if len(currency_exchange_journal) > 1:
+            raise UserError(
+                'Esta intentando conciliar deuda de más de un Store con distintos diarios para ajuste por diferencia '
+                'de cambio\n* Stores: %s\n*Diarios: %s' % (
+                    self.mapped('journal_id.store_id.name'),
+                    currency_exchange_journal.mapped('name')))
+        elif currency_exchange_journal:
+            vals['move_vals']['journal_id'] = currency_exchange_journal.id
+
+        return vals

--- a/account_multi_store/models/res_store.py
+++ b/account_multi_store/models/res_store.py
@@ -18,6 +18,7 @@ class ResStore(models.Model):
         compute='_compute_journals_count',
         string='Journals Count',
     )
+    currency_exchange_journal_id = fields.Many2one('account.journal')
     only_allow_reonciliaton_of_this_store = fields.Boolean(
         help='If enable, debt reconciliation will be only doable on items of this store')
 

--- a/account_multi_store/views/res_store_views.xml
+++ b/account_multi_store/views/res_store_views.xml
@@ -18,6 +18,7 @@
             </div>
             <group name="col2">
                 <field name="only_allow_reonciliaton_of_this_store"/>
+                <field name="currency_exchange_journal_id" attrs="{'required': [('only_allow_reonciliaton_of_this_store', '=', True)]}"/>
             </group>
             <notebook>
                 <page string="Journals" name="journals">

--- a/account_payment_group_multi_store/__manifest__.py
+++ b/account_payment_group_multi_store/__manifest__.py
@@ -39,6 +39,7 @@
         'views/res_store_view.xml',
     ],
     'demo': [
+        'demo/res_store_demo.xml',
     ],
     'installable': True,
     'auto_install': False,

--- a/account_payment_group_multi_store/__manifest__.py
+++ b/account_payment_group_multi_store/__manifest__.py
@@ -32,9 +32,11 @@
         'account',
         'base_multi_store',
         'account_payment_group',
+        'account_withholding_automatic',
     ],
     'data': [
         'views/account_payment_group_views.xml',
+        'views/res_store_view.xml',
     ],
     'demo': [
     ],

--- a/account_payment_group_multi_store/demo/res_store_demo.xml
+++ b/account_payment_group_multi_store/demo/res_store_demo.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="account_multi_store.unidad_b_store" model="res.store">
+        <field name="dont_compute_withholdings" eval="True"/>
+    </record>
+
+    <function model="res.store" name="_init_payment_group_multi_store_demo"/>
+
+</odoo>

--- a/account_payment_group_multi_store/models/__init__.py
+++ b/account_payment_group_multi_store/models/__init__.py
@@ -1,2 +1,3 @@
 from . import account_payment_group
 from . import account_payment
+from . import res_store

--- a/account_payment_group_multi_store/models/account_payment.py
+++ b/account_payment_group_multi_store/models/account_payment.py
@@ -1,4 +1,4 @@
-from odoo import models, api
+from odoo import models
 
 
 class AccountPayment(models.Model):

--- a/account_payment_group_multi_store/models/account_payment_group.py
+++ b/account_payment_group_multi_store/models/account_payment_group.py
@@ -36,3 +36,8 @@ class AccountPaymentGroup(models.Model):
     @api.depends('store_id')
     def _compute_to_pay_move_lines(self):
         super()._compute_to_pay_move_lines()
+
+    def compute_withholdings(self):
+        # only compute withholdings for payment groups where the store is not disabling it
+        return super(
+            AccountPaymentGroup, self.filtered(lambda x: not x.store_id.dont_compute_withholdings)).compute_withholdings()

--- a/account_payment_group_multi_store/models/res_store.py
+++ b/account_payment_group_multi_store/models/res_store.py
@@ -2,10 +2,32 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import models, fields
+from odoo import models, fields, api
 
 
 class ResStore(models.Model):
     _inherit = "res.store"
 
     dont_compute_withholdings = fields.Boolean()
+
+    @api.model
+    def _init_payment_group_multi_store_demo(self):
+        # TODO al depreciar este modulo en 17 (junto con payment_group) mover parte de ete codigo a account_multi_store
+
+        # por ahora lo estamos haciendo solo para main company
+        main_company = self.env.ref('base.main_company')
+
+        store_a = self.env.ref('account_multi_store.unidad_a_store')
+        # si ya configuramos diarios, seguimos adelante
+        if store_a.journal_ids:
+            return
+
+        journals = self.env[('account.journal')].search([('company_id', '=', main_company.id)])
+        journals.store_id = store_a.id
+
+        # duplicamos todos los diarios de liquidez, venta, compra y el de diferencia de cambio
+        store_b = self.env.ref('account_multi_store.unidad_b_store')
+        for journal in journals.filtered(lambda x: x.type in ['sale', 'purchase', 'bank', 'cash'] or x.code == 'EXCH'):
+            journal_b = journal.copy(default={'store_id': store_b.id})
+            journal_b.name = '%s - B' % (journal.name)
+            journal.name += ' - A'

--- a/account_payment_group_multi_store/models/res_store.py
+++ b/account_payment_group_multi_store/models/res_store.py
@@ -1,0 +1,11 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models, fields
+
+
+class ResStore(models.Model):
+    _inherit = "res.store"
+
+    dont_compute_withholdings = fields.Boolean()

--- a/account_payment_group_multi_store/views/account_payment_group_views.xml
+++ b/account_payment_group_multi_store/views/account_payment_group_views.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
             <field name="company_id" position="after">
                 <!-- lo hacemos requerido por vista porque es computado (se computa luego de crear) y ademas por si al instalar algun store no se puede definir, ademas lo hacemos solo requerido en estado borrador ya que si queda algun pago validado sin este campo, dejamos que se reabra y de ultima se seleccione -->
-                <field name="store_id" groups="base_multi_store.group_multi_store" attrs="{'required': [('state', '=', 'draft')], 'readonly': [('state', '!=', 'draft')]}" options="{'no_create': True, 'no_open': True}"/>
+                <field name="store_id" groups="base_multi_store.group_multi_store" attrs="{'required': [('state', '=', 'draft')], 'readonly': ['|', ('state', '!=', 'draft'), ('payment_ids', '!=', [])]}" options="{'no_create': True, 'no_open': True}"/>
             </field>
         </field>
     </record>

--- a/account_payment_group_multi_store/views/res_store_view.xml
+++ b/account_payment_group_multi_store/views/res_store_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <!-- Form -->
+    <record id="view_res_store_form" model="ir.ui.view">
+        <field name="name">res.store.form</field>
+        <field name="model">res.store</field>
+        <field name="inherit_id" ref="base_multi_store.view_res_store_form"/>
+        <field name="arch" type="xml">
+            <field name="only_allow_reonciliaton_of_this_store" position="after">
+                <field name="dont_compute_withholdings"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/base_multi_store/demo/res_store_demo.xml
+++ b/base_multi_store/demo/res_store_demo.xml
@@ -18,19 +18,21 @@
         <field name="company_id" ref="base.main_company"/>
     </record>
 
+    <!-- TODO tenemos que ver uso de este store y el "you company stores" porque con la nueva demo data de journals y stores a/b
+    si los usuarios no tienen el store correspondiente no van a ver nada. Ahora como está si porque estamos dando por defecto "shared_store" -->
     <record id="shared_store" model="res.store">
         <field name="name">Shared Store (No company)</field>
     </record>
 
     <!-- we add demo stores to admin user -->
     <record id="base.user_admin" model="res.users">
-        <field name="store_id" ref="main_company_stores"/>
+        <field name="store_id" ref="shared_store"/>
         <field name="store_ids" eval="[(4, ref('main_company_stores')),(4, ref('rosario_store')),(4, ref('buenos_aires_store')),(4, ref('shared_store'))]"/>
     </record>
 
     <!-- we add demo stores and store group to demo user -->
     <record id="base.user_demo" model="res.users">
-        <field name="store_id" ref="buenos_aires_store"/>
+        <field name="store_id" ref="shared_store"/>
         <field name="store_ids" eval="[(4, ref('main_company_stores')),(4, ref('rosario_store')),(4, ref('buenos_aires_store')),(4, ref('shared_store'))]"/>
         <field name="groups_id" eval="[(4, ref('group_multi_store'))]"/>
     </record>


### PR DESCRIPTION
Movemos lo que habíamos desarrollado acá para que quede de manera genérica: https://github.com/ingadhoc/personalizations/pull/1029/files

No es muy elegante que requiera agregar dependencia a "account_withholding_automatic" pero tampoco es un problema porque: a) payment group de por si existe para poder computar retenciones b) el modulo pay group multi store no lo usa nadie todavia c) en 17 vamos a depreciar todos estos modulos por lo cual generar uno nuevo tampoco tiene tanto sentido