### PR TITLE
[FIX] account_payment_group_multi_store: payment from invoice

### DIFF
--- a/account_payment_group_multi_store/__manifest__.py
+++ b/account_payment_group_multi_store/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Multi Store on Payment Groups',
-    'version': '16.0.1.0.0',
+    'version': '16.0.1.1.0',
     'category': 'Accounting',
     'sequence': 14,
     'summary': '',

--- a/account_payment_group_multi_store/models/account_payment_group.py
+++ b/account_payment_group_multi_store/models/account_payment_group.py
@@ -6,10 +6,7 @@ class AccountPaymentGroup(models.Model):
 
     store_id = fields.Many2one(
         'res.store',
-        compute='_compute_store_id',
         readonly=False,
-        store=True,
-        # default=lambda self: self.env.user.store_id,
     )
 
     @api.model_create_multi

--- a/account_payment_group_multi_store/models/account_payment_group.py
+++ b/account_payment_group_multi_store/models/account_payment_group.py
@@ -12,13 +12,22 @@ class AccountPaymentGroup(models.Model):
         # default=lambda self: self.env.user.store_id,
     )
 
-    @api.depends('payment_ids')
-    def _compute_store_id(self):
-        # tal vez en este caso buscar un store padre que de alguna manera da
-        # permiso para todos estos stores?
-        for rec in self.filtered(lambda x: not x.store_id):
+    @api.model_create_multi
+    def create(self, vals_list):
+        """ Heredamos el create por si algun codigo de ecommerce o similra crea payemtns y payments groups
+        sin store y para intentar dejarlo asignado.
+        Tal vez en vez de ser en el create podria ser en un action_post?
+        Anteriormente estabamos conviriendo store_id a computado almacenado, pero había una suerte de recursividad
+        que nos traia problemas al menos en el caso en el cual veníamos desde pagar una factura (se mostraba bien
+        pero al querer agregar un pago nos recalculaba toda la deuda)
+        La realidad es que si esto nos trae problemas podríamos ignorar y ni siquiera computar este dato"""
+        recs = super().create(vals_list)
+        for rec in recs.filtered(lambda x: not x.store_id):
             if len(rec.payment_ids.mapped('journal_id.store_id')) == 1:
-                rec.store_id = rec.payment_ids.mapped('journal_id.store_id')
+                rec.store_id = rec.payment_ids.mapped('journal_id.store_id').id
+            elif len(rec.to_pay_move_line_ids.mapped('journal_id.store_id')) == 1:
+                rec.store_id = rec.to_pay_move_line_ids.mapped('journal_id.store_id').id
+        return recs
 
     def _get_to_pay_move_lines_domain(self):
         """ Si soy pago de un payment group con store, y :
@@ -33,6 +42,8 @@ class AccountPaymentGroup(models.Model):
 
     @api.depends('store_id')
     def _compute_to_pay_move_lines(self):
+        if self._context.get('default_to_pay_move_line_ids'):
+            return
         super()._compute_to_pay_move_lines()
 
     def compute_withholdings(self):

--- a/account_payment_group_multi_store/views/account_payment_group_views.xml
+++ b/account_payment_group_multi_store/views/account_payment_group_views.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
             <field name="company_id" position="after">
                 <!-- lo hacemos requerido por vista porque es computado (se computa luego de crear) y ademas por si al instalar algun store no se puede definir, ademas lo hacemos solo requerido en estado borrador ya que si queda algun pago validado sin este campo, dejamos que se reabra y de ultima se seleccione -->
-                <field name="store_id" groups="base_multi_store.group_multi_store" attrs="{'required': [('state', '=', 'draft')], 'readonly': ['|', ('state', '!=', 'draft'), ('payment_ids', '!=', [])]}" options="{'no_create': True, 'no_open': True}"/>
+                <field name="store_id" groups="base_multi_store.group_multi_store" attrs="{'required': [('state', '=', 'draft')], 'readonly': ['|', ('state', '!=', 'draft'), ('payment_ids', '!=', [])]}" options="{'no_create': True, 'no_open': True}" invisible="context.get('pop_up')"/>
             </field>
         </field>
     </record>

--- a/account_payment_group_multi_store/views/account_payment_group_views.xml
+++ b/account_payment_group_multi_store/views/account_payment_group_views.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
             <field name="company_id" position="after">
                 <!-- lo hacemos requerido por vista porque es computado (se computa luego de crear) y ademas por si al instalar algun store no se puede definir, ademas lo hacemos solo requerido en estado borrador ya que si queda algun pago validado sin este campo, dejamos que se reabra y de ultima se seleccione -->
-                <field name="store_id" groups="base_multi_store.group_multi_store" attrs="{'required': [('state', '=', 'draft')], 'readonly': ['|', ('state', '!=', 'draft'), ('payment_ids', '!=', [])]}" options="{'no_create': True, 'no_open': True}" invisible="context.get('pop_up')"/>
+                <field name="store_id" groups="base_multi_store.group_multi_store" attrs="{'required': [('state', '=', 'draft')], 'readonly': ['|', ('state', '!=', 'draft'), ('payment_ids', '!=', [])]}" options="{'no_create': True, 'no_open': True}" invisible="context.get('pop_up')" force_save="True"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Anteriormente estabamos computando el campo store_id con _compute_store_id pero eso nos traia cierta recursividad porque en esta version el campo _compute_to_pay_move_lines es comutado.

Entonces lo que papsaba al pagar desde una factura era que previsuualizaba bien la deuda seleccionada pero cuando ibas a gregar una línea recomputaba deuda porque en realidad estaba recomputando el store (aunque en realidad no se estaba cambiando).

Este no es el fix mas hermoso pero tmb es verdad que en teoría vamos a deprecar esto en 17

Otra alternativa podría ser al revez, dejar computado el store_id y cambiar _compute_to_pay_move_lines y llamarlo por un onchange (pero no funciono a primera)

NOTA: estaría faltando una mejora/fix de algo que se perdió en 16 y es que al pagar desde una factura los campos stores, partner y demas quedan editables cuando no deberían serlo