### PR TITLE
[FIX] account_multi_store: Include archived journals in search

### DIFF
--- a/account_multi_store/models/account_journal.py
+++ b/account_multi_store/models/account_journal.py
@@ -28,4 +28,4 @@ class AccountJournal(models.Model):
         # if superadmin, do not apply
         if not self.env.is_superuser():
             args += ['|', ('store_id', '=', False), ('store_id', 'child_of', [user.store_id.id])]
-        return super()._search(args, offset, limit, order, count=count, access_rights_uid=access_rights_uid)
+        return super(AccountJournal, self.with_context(active_test=False))._search(args, offset, limit, order, count=count, access_rights_uid=access_rights_uid)


### PR DESCRIPTION
Ensure that archived journals are included in the search 
by applying active_test=False in _search().
This allows users to modify archived journals,
such as unarchiving them