### PR TITLE
[FIX] stock_multi_store:  Enhance search logic to include context for  stock order points

### DIFF
--- a/stock_multi_store/__manifest__.py
+++ b/stock_multi_store/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Multi Store for Warehouse",
-    "version": "18.0.1.2.0",
+    "version": "18.0.1.3.0",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",

--- a/stock_multi_store/models/stock_rule.py
+++ b/stock_multi_store/models/stock_rule.py
@@ -18,7 +18,8 @@ class StockRule(models.Model):
         """
         user = self.env.user
         # if superadmin, do not apply
-        if not self.with_user(user.id).env.is_superuser():
+        # El contexto search_default_filter_not_snoozed se agrega para ver sale order points que era donde fallaba
+        if not self.env.is_superuser() and self.env.context.get("search_default_filter_not_snoozed"):
             args += [
                 "|",
                 ("warehouse_id.store_id", "=", False),

--- a/stock_multi_store/security/multi_store_security.xml
+++ b/stock_multi_store/security/multi_store_security.xml
@@ -25,13 +25,4 @@
         <field name="perm_read" eval="False"/>
         <field name="domain_force">['|', ('picking_type_id.code','=','dropship'),'|',('picking_type_id.warehouse_id.store_id','=',False),('picking_type_id.warehouse_id.store_id','child_of',[user.store_id.id])]</field>
     </record>
-
-    <record id="stock_rule_rule" model="ir.rule">
-        <field name="name">Stock Rule multi-store</field>
-        <field name="model_id" ref="stock.model_stock_rule"/>
-        <field name="global" eval="True"/>
-        <field name="perm_read" eval="False"/>
-        <field name="domain_force">['|',('warehouse_id.store_id','=',False),('warehouse_id.store_id','child_of',[user.store_id.id])]</field>
-    </record>
-
 </odoo>


### PR DESCRIPTION


Adjusted the search logic to include an additional domain in the context, applicable only to replenishment cases in stock order points. This change aims to improve the filtering of stock rules based on user permissions and store associations.